### PR TITLE
fix (protocol): resolve l1 and l2 contracts tests

### DIFF
--- a/packages/protocol/contracts/layer1/based/TaikoL1.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoL1.sol
@@ -293,7 +293,7 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents {
     /// @inheritdoc ITaikoL1
     function getConfig() public pure virtual returns (TaikoData.Config memory) {
         return TaikoData.Config({
-            chainId: 8787,
+            chainId: LibNetwork.TAIKO_MAINNET,
             blockMaxProposals: 324_000, // = 7200 * 45
             blockRingBufferSize: 360_000, // = 7200 * 50
             maxBlocksToVerify: 16,
@@ -308,7 +308,7 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents {
                 minGasExcess: 1_340_000_000,
                 maxGasIssuancePerBlock: 600_000_000 // two minutes
              }),
-            ontakeForkHeight: 2 // = 7200 * 52
+            ontakeForkHeight: 374_400 // = 7200 * 52
          });
     }
 

--- a/packages/protocol/contracts/layer1/testnet/TestnetTierProvider.sol
+++ b/packages/protocol/contracts/layer1/testnet/TestnetTierProvider.sol
@@ -10,7 +10,7 @@ import "../../../contracts/layer1/tiers/ITierRouter.sol";
 /// @dev Labeled in AddressResolver as "tier_router"
 /// @custom:security-contact security@taiko.xyz
 contract TestnetTierProvider is ITierProvider, ITierRouter {
-    uint256[50] private __gap;
+uint256[50] private __gap;
 
     /// @inheritdoc ITierRouter
     function getProvider(uint256) external view returns (address) {
@@ -19,17 +19,6 @@ contract TestnetTierProvider is ITierProvider, ITierRouter {
     /// @inheritdoc ITierProvider
 
     function getTier(uint16 _tierId) public pure override returns (ITierProvider.Tier memory) {
-        if (_tierId == LibTiers.TIER_OPTIMISTIC) {
-            return ITierProvider.Tier({
-                verifierName: "",
-                validityBond: 250 ether, // TKO
-                contestBond: 500 ether, // TKO
-                cooldownWindow: 1, // 1 minute
-                provingWindow: 30, // 0.5 hours
-                maxBlocksToVerifyPerProof: 0
-            });
-        }
-
         if (_tierId == LibTiers.TIER_TDX) {
             return ITierProvider.Tier({
                 verifierName: LibStrings.B_TIER_TDX,
@@ -58,16 +47,12 @@ contract TestnetTierProvider is ITierProvider, ITierRouter {
     /// @inheritdoc ITierProvider
     function getTierIds() public pure override returns (uint16[] memory tiers_) {
         tiers_ = new uint16[](3);
-        tiers_[0] = LibTiers.TIER_OPTIMISTIC;
-        tiers_[1] = LibTiers.TIER_TDX;
-        tiers_[2] = LibTiers.TIER_GUARDIAN;
+        tiers_[0] = LibTiers.TIER_TDX;
+        tiers_[1] = LibTiers.TIER_GUARDIAN;
     }
 
     /// @inheritdoc ITierProvider
     function getMinTier(address, uint256 _rand) public pure override returns (uint16) {
-        // 10% will be selected to require TDX proofs.
-        if (_rand % 10 == 0) return LibTiers.TIER_TDX;
-        // Other blocks are optimistic, without validity proofs.
-        return LibTiers.TIER_OPTIMISTIC;
+        return LibTiers.TIER_TDX;
     }
 }

--- a/packages/protocol/contracts/layer1/testnet/TestnetTierProvider.sol
+++ b/packages/protocol/contracts/layer1/testnet/TestnetTierProvider.sol
@@ -8,7 +8,6 @@ import "../../../contracts/layer1/tiers/ITierRouter.sol";
 
 /// @title TestnetTierProvider
 /// @dev Labeled in AddressResolver as "tier_router"
-/// @custom:security-contact security@taiko.xyz
 contract TestnetTierProvider is ITierProvider, ITierRouter {
     uint256[50] private __gap;
 
@@ -16,8 +15,8 @@ contract TestnetTierProvider is ITierProvider, ITierRouter {
     function getProvider(uint256) external view returns (address) {
         return address(this);
     }
-    /// @inheritdoc ITierProvider
 
+    /// @inheritdoc ITierProvider
     function getTier(uint16 _tierId) public pure override returns (ITierProvider.Tier memory) {
         if (_tierId == LibTiers.TIER_TDX) {
             return ITierProvider.Tier({

--- a/packages/protocol/contracts/layer1/testnet/TestnetTierProvider.sol
+++ b/packages/protocol/contracts/layer1/testnet/TestnetTierProvider.sol
@@ -10,7 +10,7 @@ import "../../../contracts/layer1/tiers/ITierRouter.sol";
 /// @dev Labeled in AddressResolver as "tier_router"
 /// @custom:security-contact security@taiko.xyz
 contract TestnetTierProvider is ITierProvider, ITierRouter {
-uint256[50] private __gap;
+    uint256[50] private __gap;
 
     /// @inheritdoc ITierRouter
     function getProvider(uint256) external view returns (address) {

--- a/packages/protocol/contracts/layer1/testnet/TestnetTierProvider.sol
+++ b/packages/protocol/contracts/layer1/testnet/TestnetTierProvider.sol
@@ -6,10 +6,10 @@ import "../../../contracts/layer1/tiers/ITierProvider.sol";
 import "../../../contracts/layer1/tiers/LibTiers.sol";
 import "../../../contracts/layer1/tiers/ITierRouter.sol";
 
-/// @title TestTierProvider
+/// @title TestnetTierProvider
 /// @dev Labeled in AddressResolver as "tier_router"
 /// @custom:security-contact security@taiko.xyz
-contract TestTierProvider is ITierProvider, ITierRouter {
+contract TestnetTierProvider is ITierProvider, ITierRouter {
     uint256[50] private __gap;
 
     /// @inheritdoc ITierRouter
@@ -24,18 +24,18 @@ contract TestTierProvider is ITierProvider, ITierRouter {
                 verifierName: "",
                 validityBond: 250 ether, // TKO
                 contestBond: 500 ether, // TKO
-                cooldownWindow: 1440, //24 hours
+                cooldownWindow: 1, // 1 minute
                 provingWindow: 30, // 0.5 hours
                 maxBlocksToVerifyPerProof: 0
             });
         }
 
-        if (_tierId == LibTiers.TIER_SGX) {
+        if (_tierId == LibTiers.TIER_TDX) {
             return ITierProvider.Tier({
-                verifierName: LibStrings.B_TIER_SGX,
+                verifierName: LibStrings.B_TIER_TDX,
                 validityBond: 250 ether, // TKO
                 contestBond: 1640 ether, // =250TKO * 6.5625
-                cooldownWindow: 1440, //24 hours
+                cooldownWindow: 1, // 1 minute
                 provingWindow: 60, // 1 hours
                 maxBlocksToVerifyPerProof: 0
             });
@@ -46,7 +46,7 @@ contract TestTierProvider is ITierProvider, ITierRouter {
                 verifierName: LibStrings.B_TIER_GUARDIAN,
                 validityBond: 0, // must be 0 for top tier
                 contestBond: 0, // must be 0 for top tier
-                cooldownWindow: 60, //1 hours
+                cooldownWindow: 1, //1 minute
                 provingWindow: 2880, // 48 hours
                 maxBlocksToVerifyPerProof: 0
             });
@@ -59,14 +59,14 @@ contract TestTierProvider is ITierProvider, ITierRouter {
     function getTierIds() public pure override returns (uint16[] memory tiers_) {
         tiers_ = new uint16[](3);
         tiers_[0] = LibTiers.TIER_OPTIMISTIC;
-        tiers_[1] = LibTiers.TIER_SGX;
+        tiers_[1] = LibTiers.TIER_TDX;
         tiers_[2] = LibTiers.TIER_GUARDIAN;
     }
 
     /// @inheritdoc ITierProvider
     function getMinTier(address, uint256 _rand) public pure override returns (uint16) {
-        // 10% will be selected to require SGX proofs.
-        if (_rand % 10 == 0) return LibTiers.TIER_SGX;
+        // 10% will be selected to require TDX proofs.
+        if (_rand % 10 == 0) return LibTiers.TIER_TDX;
         // Other blocks are optimistic, without validity proofs.
         return LibTiers.TIER_OPTIMISTIC;
     }

--- a/packages/protocol/script/layer1/DeployProtocolOnL1.s.sol
+++ b/packages/protocol/script/layer1/DeployProtocolOnL1.s.sol
@@ -25,6 +25,7 @@ import "../../contracts/layer1/mainnet/rollup/MainnetGuardianProver.sol";
 import "../../contracts/layer1/mainnet/rollup/MainnetTaikoL1.sol";
 import "../../contracts/layer1/mainnet/rollup/verifiers/MainnetSgxVerifier.sol";
 import "../../contracts/layer1/testnet/TestnetUniFiL1.sol";
+import "../../contracts/layer1/testnet/TestnetTierProvider.sol";
 import "../../contracts/layer1/verifiers/ProverRegistryVerifier.sol";
 import "../../contracts/layer1/mainnet/multirollup/MainnetBridge.sol";
 import "../../contracts/layer1/mainnet/multirollup/MainnetERC1155Vault.sol";
@@ -37,7 +38,6 @@ import "../../contracts/layer1/tiers/TierProviderV2.sol";
 import "../../contracts/layer1/token/TaikoToken.sol";
 import "../../contracts/layer1/verifiers/Risc0Verifier.sol";
 import "../../contracts/layer1/verifiers/SP1Verifier.sol";
-import "../../test/layer1/based/TestTierProvider.sol";
 import "../../test/shared/token/FreeMintERC20.sol";
 import "../../test/shared/token/MayFailFreeMintERC20.sol";
 import "../../test/shared/DeployCapability.sol";
@@ -452,7 +452,7 @@ contract DeployProtocolOnL1 is DeployCapability {
         if (keccak256(abi.encode(tierProviderName)) == keccak256(abi.encode("devnet"))) {
             return address(new DevnetTierProvider());
         } else if (keccak256(abi.encode(tierProviderName)) == keccak256(abi.encode("testnet"))) {
-            return address(new TestTierProvider());
+            return address(new TestnetTierProvider());
         } else if (keccak256(abi.encode(tierProviderName)) == keccak256(abi.encode("mainnet"))) {
             return address(new TierProviderV2());
         } else {


### PR DESCRIPTION
## Changes
- Revert changes to `TestTierProvider.sol` and create `TestnetTierProvider.sol` which contains the changes
- Revert unnecessary changes to `TaikoL1.sol`
- Adjust `DeployProtocolOnL1.s.sol` to use TestnetTierProvider.

