### PR TITLE
fix: Error pull access denied for unifi-client

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,9 @@ services:
   prover:
     image: unifi-client
     container_name: unifi-client-prover
+    build:
+      context: .
+      dockerfile: ./packages/taiko-client/Dockerfile
     restart: unless-stopped
     pull_policy: always
     command:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Fixes:
```
 ✘ prover Error pull access denied for unifi-client, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```


#### Which issue(s) does this PR fixes:
AB#3243
<!--  For internal Puffer folks, please tag this PR to an internal user story ID for traceability -->



#### Additional comments:
