### PR TITLE
resolve the issues related to ProverRegistry and AttestationVerifier on OZ Audit report

### DIFF
--- a/packages/protocol/contracts/layer1/automata-attestation/AttestationVerifier.sol
+++ b/packages/protocol/contracts/layer1/automata-attestation/AttestationVerifier.sol
@@ -9,31 +9,48 @@ import "./interfaces/IAttestationVerifier.sol";
 contract AttestationVerifier is IAttestationVerifier, EssentialContract {
     IAttestationV2 public automataDcapAttestation; // slot 1
     mapping(bytes32 pcr10 => bool trusted) public trustedPcr10; // slot 2
-    bool checkPcr10; // slot3
+    bool internal checkPcr10; // slot3
 
     uint256[47] private __gap;
 
-    function init(
-        address _owner,
-        address _automataDcapAttestation,
-        bool _checkPcr10
-    )
-        external
-        initializer
-    {
-        __Essential_init(_owner);
-        automataDcapAttestation = IAttestationV2(_automataDcapAttestation);
-        checkPcr10 = _checkPcr10;
-    }
+function init(
+    address _owner,
+    address _automataDcapAttestation,
+    bool _checkPcr10
+)
+    external
+    initializer
+{
+    __Essential_init(_owner);
+    automataDcapAttestation = IAttestationV2(_automataDcapAttestation);
+    checkPcr10 = _checkPcr10;
+    emit AttestationVerifierInitialized(_owner, _automataDcapAttestation, _checkPcr10);
+}
 
+    /// @notice Sets whether PCR10 verification is enabled
+    /// @param _check If true, PCR10 values will be verified against trusted values
     function setCheckPcr10(bool _check) external onlyOwner {
         checkPcr10 = _check;
+        emit CheckPcr10Updated(_check);
     }
 
+    /// @notice Sets whether a specific PCR10 value is trusted
+    /// @param _pcr10 The PCR10 value to configure
+    /// @param _trusted If true, this PCR10 value will be considered trusted
     function setImagePcr10(bytes32 _pcr10, bool _trusted) external onlyOwner {
         trustedPcr10[_pcr10] = _trusted;
+        emit ImagePcr10Updated(_pcr10, _trusted);
     }
 
+    /// @notice Verifies an attestation report
+    /// @param _report The attestation report to verify
+    /// @param _userData User data that should match the report data
+    /// @param _ext Additional TPM information encoded as ExtTpmInfo
+    /// @dev Verifies that:
+    ///      1. The report is valid via automataDcapAttestation
+    ///      2. The report data matches the hash of (akDer + userData)
+    ///      3. If checkPcr10 is enabled, verifies pcr10 is trusted
+    /// @inheritdoc IAttestationVerifier
     function verifyAttestation(
         bytes calldata _report,
         bytes32 _userData,
@@ -50,7 +67,8 @@ contract AttestationVerifier is IAttestationVerifier, EssentialContract {
 
         bytes32 quoteBodyLast32;
         assembly {
-            quoteBodyLast32 := mload(add(add(output, 0x20), sub(mload(output), 32)))
+            // Calculate offset directly using output length
+            quoteBodyLast32 := mload(add(output, mload(output)))
         }
 
         ExtTpmInfo memory info = abi.decode(_ext, (ExtTpmInfo));

--- a/packages/protocol/contracts/layer1/automata-attestation/AttestationVerifier.sol
+++ b/packages/protocol/contracts/layer1/automata-attestation/AttestationVerifier.sol
@@ -30,7 +30,7 @@ contract AttestationVerifier is IAttestationVerifier, EssentialContract {
         __Essential_init(_owner);
         automataDcapAttestation = IAttestationV2(_automataDcapAttestation);
         checkPcr10 = _checkPcr10;
-        emit AttestationVerifierInitialized(_owner, _automataDcapAttestation, _checkPcr10);
+        emit AttestationVerifierInitialized(_automataDcapAttestation, _checkPcr10);
     }
 
     /// @notice Sets whether PCR10 verification is enabled

--- a/packages/protocol/contracts/layer1/automata-attestation/AttestationVerifier.sol
+++ b/packages/protocol/contracts/layer1/automata-attestation/AttestationVerifier.sol
@@ -13,19 +13,25 @@ contract AttestationVerifier is IAttestationVerifier, EssentialContract {
 
     uint256[47] private __gap;
 
-function init(
-    address _owner,
-    address _automataDcapAttestation,
-    bool _checkPcr10
-)
-    external
-    initializer
-{
-    __Essential_init(_owner);
-    automataDcapAttestation = IAttestationV2(_automataDcapAttestation);
-    checkPcr10 = _checkPcr10;
-    emit AttestationVerifierInitialized(_owner, _automataDcapAttestation, _checkPcr10);
-}
+    /// @notice Initializes the AttestationVerifier contract
+    /// @param _owner The address that will be granted ownership permissions
+    /// @param _automataDcapAttestation Address of the Automata DCAP attestation contract. If set to address(0),
+    ///        the contract will operate in mock mode and bypass all attestation verification
+    /// @param _checkPcr10 If true, enables PCR10 verification against trusted values
+    /// @dev Sets up the contract with initial configuration and emits an event upon completion
+    function init(
+        address _owner,
+        address _automataDcapAttestation,
+        bool _checkPcr10
+    )
+        external
+        initializer
+    {
+        __Essential_init(_owner);
+        automataDcapAttestation = IAttestationV2(_automataDcapAttestation);
+        checkPcr10 = _checkPcr10;
+        emit AttestationVerifierInitialized(_owner, _automataDcapAttestation, _checkPcr10);
+    }
 
     /// @notice Sets whether PCR10 verification is enabled
     /// @param _check If true, PCR10 values will be verified against trusted values

--- a/packages/protocol/contracts/layer1/automata-attestation/interfaces/IAttestationV2.sol
+++ b/packages/protocol/contracts/layer1/automata-attestation/interfaces/IAttestationV2.sol
@@ -31,7 +31,8 @@ interface IAttestationV2 {
         returns (bool success, bytes memory output);
 
     /**
-     * @param journal - The output of the Guest program, this includes:
+     * @notice Verifies an attestation using ZK proof and processes the result
+     * @param journal The output of the Guest program, this includes:
      * - VerifiedOutput struct
      * - TcbInfo hash
      * - QEID hash
@@ -40,7 +41,10 @@ interface IAttestationV2 {
      * - Root CRL hash
      * - Platform CRL hash
      * - Processor CRL hash
-     * @param seal - The encoded cryptographic proof (i.e. SNARK).
+     * @param seal The encoded cryptographic proof (i.e. SNARK)
+     * @return success Whether the verification was successful
+     * @return output The verification result data. For successful verifications, contains processed output.
+     * For failures, contains a UTF-8 encoded error message
      */
     function verifyAndAttestWithZKProof(
         bytes calldata journal,

--- a/packages/protocol/contracts/layer1/automata-attestation/interfaces/IAttestationVerifier.sol
+++ b/packages/protocol/contracts/layer1/automata-attestation/interfaces/IAttestationVerifier.sol
@@ -15,6 +15,10 @@ interface IAttestationVerifier {
     error REPORT_DATA_MISMATCH(bytes32 want, bytes32 got);
     error INVALID_PRC10(bytes32 pcr10);
 
+    event AttestationVerifierInitialized(address owner, address attestation, bool checkPcr10);
+    event CheckPcr10Updated(bool check);
+    event ImagePcr10Updated(bytes32 pcr10, bool trusted);
+
     function setImagePcr10(bytes32 _pcr10, bool _trusted) external;
     function verifyAttestation(
         bytes calldata _report,

--- a/packages/protocol/contracts/layer1/automata-attestation/interfaces/IAttestationVerifier.sol
+++ b/packages/protocol/contracts/layer1/automata-attestation/interfaces/IAttestationVerifier.sol
@@ -3,11 +3,12 @@ pragma solidity ^0.8.24;
 
 /// @title IAttestationVerifier
 interface IAttestationVerifier {
+    /// @dev TPM Extended Information structure containing attestation-related data
     struct ExtTpmInfo {
-        bytes32 pcr10;
-        bytes quote;
-        bytes signature;
-        bytes akDer;
+        bytes32 pcr10;     /// Platform Configuration Register 10 value
+        bytes quote;       /// TPM quote data
+        bytes signature;   /// Signature over the quote
+        bytes akDer;      /// Attestation Key in DER format
     }
 
     error INVALID_REPORT();
@@ -19,7 +20,16 @@ interface IAttestationVerifier {
     event CheckPcr10Updated(bool check);
     event ImagePcr10Updated(bytes32 pcr10, bool trusted);
 
+    /// @notice Sets the trust status for a PCR10 value
+    /// @param _pcr10 The PCR10 value to configure
+    /// @param _trusted If true, this PCR10 value will be considered trusted
     function setImagePcr10(bytes32 _pcr10, bool _trusted) external;
+
+    /// @notice Verifies an attestation report and its associated data
+    /// @param _report The attestation report to verify
+    /// @param _userData User data that should match the report data
+    /// @param ext Additional TPM information encoded as ExtTpmInfo
+    /// @dev If attestation contract is set to address(0), verification is bypassed (mock mode)
     function verifyAttestation(
         bytes calldata _report,
         bytes32 _userData,

--- a/packages/protocol/contracts/layer1/automata-attestation/interfaces/IAttestationVerifier.sol
+++ b/packages/protocol/contracts/layer1/automata-attestation/interfaces/IAttestationVerifier.sol
@@ -16,7 +16,7 @@ interface IAttestationVerifier {
     error REPORT_DATA_MISMATCH(bytes32 want, bytes32 got);
     error INVALID_PRC10(bytes32 pcr10);
 
-    event AttestationVerifierInitialized(address owner, address attestation, bool checkPcr10);
+    event AttestationVerifierInitialized(address attestation, bool checkPcr10);
     event CheckPcr10Updated(bool check);
     event ImagePcr10Updated(bytes32 pcr10, bool trusted);
 

--- a/packages/protocol/contracts/layer1/verifiers/IProverRegistry.sol
+++ b/packages/protocol/contracts/layer1/verifiers/IProverRegistry.sol
@@ -43,6 +43,8 @@ interface IProverRegistry {
     error PROVER_TYPE_MISMATCH();
     error PROVER_ADDR_MISMATCH(address, address);
     error PROVER_OUT_OF_DATE(uint256);
+    error INVALID_ATTEST_VALIDITY_SECONDS();
+    error MAX_BLOCK_NUMBER_DIFF_TOO_LARGE();
 
     // attestation verifier
     error INVALID_REPORT();
@@ -54,11 +56,35 @@ interface IProverRegistry {
         uint256 indexed id, address indexed instance, address replaced, uint256 validUntil
     );
     event VerifyProof(uint256 proofs);
+    event ProverRegistryInitialized(
+        address verifier,
+        uint256 attestValiditySeconds,
+        uint256 maxBlockNumberDiff
+    );
 
-    /// @notice register prover instance with quote
+    /**
+     * @notice Register a new prover instance with attestation quote
+     * @param _report The attestation report containing the TEE quote
+     * @param _data The report data containing prover details:
+     *        - addr: The prover's address
+     *        - teeType: Type of TEE (1 for IntelTDX)
+     *        - referenceBlockNumber: Block number for verification
+     *        - referenceBlockHash: Block hash for verification
+     *        - binHash: Hash of the binary
+     *        - ext: Additional extension data
+     */
     function register(bytes calldata _report, ReportData calldata _data) external;
 
-    /// @notice validate whether the prover with (instanceID, address)
+    /**
+     * @notice Validate a prover instance
+     * @param _instanceID The unique identifier of the prover instance
+     * @param _proverAddr The address of the prover to validate
+     * @return ProverInstance containing:
+     *         - addr: The prover's address
+     *         - validUntil: Timestamp until which the prover is valid
+     *         - teeType: Type of TEE (1 for IntelTDX)
+     * @dev Reverts if instance ID is invalid, prover address mismatch, or instance expired
+     */
     function checkProver(
         uint256 _instanceID,
         address _proverAddr

--- a/packages/protocol/contracts/layer1/verifiers/IProverRegistry.sol
+++ b/packages/protocol/contracts/layer1/verifiers/IProverRegistry.sol
@@ -40,6 +40,7 @@ interface IProverRegistry {
     error PROVER_INVALID_PROOF();
     error PROVER_INVALID_INSTANCE_ID(uint256);
     error PROVER_INVALID_ADDR(address);
+    error VERIFIER_INVALID_ADDR();
     error PROVER_TYPE_MISMATCH();
     error PROVER_ADDR_MISMATCH(address, address);
     error PROVER_OUT_OF_DATE(uint256);

--- a/packages/protocol/contracts/layer1/verifiers/ProverRegistryVerifier.sol
+++ b/packages/protocol/contracts/layer1/verifiers/ProverRegistryVerifier.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.24;
 
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import "../../shared/common/EssentialContract.sol";
 import "../automata-attestation/interfaces/IAttestationVerifier.sol";
 import "../../shared/common/LibStrings.sol";
@@ -12,6 +13,8 @@ import "./IVerifier.sol";
 import "./LibPublicInput.sol";
 
 contract ProverRegistryVerifier is IVerifier, IProverRegistry, EssentialContract {
+    using SafeCast for uint256;
+
     IAttestationVerifier public verifier; // slot 1
 
     // Pack these variables into a single slot 2
@@ -52,8 +55,8 @@ contract ProverRegistryVerifier is IVerifier, IProverRegistry, EssentialContract
         if (_maxBlockNumberDiff > 256) revert MAX_BLOCK_NUMBER_DIFF_TOO_LARGE();
 
         verifier = IAttestationVerifier(_verifierAddr);
-        attestValiditySeconds = uint64(_attestValiditySeconds);
-        maxBlockNumberDiff = uint64(_maxBlockNumberDiff);
+        attestValiditySeconds = _attestValiditySeconds.toUint64();
+        maxBlockNumberDiff = _maxBlockNumberDiff.toUint64();
         emit ProverRegistryInitialized(_verifierAddr, _attestValiditySeconds, _maxBlockNumberDiff);
     }
 
@@ -78,8 +81,8 @@ contract ProverRegistryVerifier is IVerifier, IProverRegistry, EssentialContract
         if (_maxBlockNumberDiff > 256) revert MAX_BLOCK_NUMBER_DIFF_TOO_LARGE();
 
         verifier = IAttestationVerifier(_verifierAddr);
-        attestValiditySeconds = uint64(_attestValiditySeconds);
-        maxBlockNumberDiff = uint64(_maxBlockNumberDiff);
+        attestValiditySeconds = _attestValiditySeconds.toUint64();
+        maxBlockNumberDiff = _maxBlockNumberDiff.toUint64();
         emit ProverRegistryInitialized(_verifierAddr, _attestValiditySeconds, _maxBlockNumberDiff);
     }
 

--- a/packages/protocol/contracts/layer1/verifiers/ProverRegistryVerifier.sol
+++ b/packages/protocol/contracts/layer1/verifiers/ProverRegistryVerifier.sol
@@ -13,14 +13,16 @@ import "./LibPublicInput.sol";
 
 contract ProverRegistryVerifier is IVerifier, IProverRegistry, EssentialContract {
     IAttestationVerifier public verifier; // slot 1
-    uint256 public attestValiditySeconds; // slot 2
-    uint256 public maxBlockNumberDiff; // slot 3
-    uint256 public nextInstanceId = 0; // slot 4
 
-    mapping(bytes32 reportHash => bool used) public attestedReports; // slot 5
-    mapping(uint256 proverInstanceID => ProverInstance) public attestedProvers; // slot 6
+    // Pack these variables into a single slot 2
+    uint64 public attestValiditySeconds;
+    uint64 public maxBlockNumberDiff;
+    uint128 public nextInstanceId;
 
-    uint256[44] private __gap;
+    mapping(bytes32 reportHash => bool used) public attestedReports; // slot 3
+    mapping(uint256 proverInstanceID => ProverInstance) public attestedProvers; // slor 4
+
+    uint256[46] private __gap;
 
     function init(
         address _owner,
@@ -34,11 +36,22 @@ contract ProverRegistryVerifier is IVerifier, IProverRegistry, EssentialContract
     {
         __Essential_init(_owner, _rollupAddressManager);
 
+        if (_verifierAddr == address(0)) revert PROVER_INVALID_ADDR(_verifierAddr);
+        if (_attestValiditySeconds == 0) revert INVALID_ATTEST_VALIDITY_SECONDS();
+        if (_maxBlockNumberDiff > 256) revert MAX_BLOCK_NUMBER_DIFF_TOO_LARGE();
+
         verifier = IAttestationVerifier(_verifierAddr);
-        attestValiditySeconds = _attestValiditySeconds;
-        maxBlockNumberDiff = _maxBlockNumberDiff;
+        attestValiditySeconds = uint64(_attestValiditySeconds);
+        maxBlockNumberDiff = uint64(_maxBlockNumberDiff);
+        emit ProverRegistryInitialized(_verifierAddr, _attestValiditySeconds, _maxBlockNumberDiff);
     }
 
+    /// @notice Reinitializes the contract with new parameters
+    /// @param i The version number for reinitialization
+    /// @param _verifierAddr The address of the new attestation verifier
+    /// @param _attestValiditySeconds New duration for attestation validity
+    /// @param _maxBlockNumberDiff New maximum block number difference allowed
+    /// @dev Can only be called by the owner and uses OpenZeppelin's reinitializer
     function reinitialize(
         uint8 i,
         address _verifierAddr,
@@ -49,12 +62,30 @@ contract ProverRegistryVerifier is IVerifier, IProverRegistry, EssentialContract
         onlyOwner
         reinitializer(i)
     {
+        if (_verifierAddr == address(0)) revert PROVER_INVALID_ADDR(_verifierAddr);
+        if (_attestValiditySeconds == 0) revert INVALID_ATTEST_VALIDITY_SECONDS();
+        if (_maxBlockNumberDiff > 256) revert MAX_BLOCK_NUMBER_DIFF_TOO_LARGE();
+
         verifier = IAttestationVerifier(_verifierAddr);
-        attestValiditySeconds = _attestValiditySeconds;
-        maxBlockNumberDiff = _maxBlockNumberDiff;
+        attestValiditySeconds = uint64(_attestValiditySeconds);
+        maxBlockNumberDiff = uint64(_maxBlockNumberDiff);
+        emit ProverRegistryInitialized(_verifierAddr, _attestValiditySeconds, _maxBlockNumberDiff);
     }
 
-    /// @notice register prover instance with quote
+    /**
+     * @notice Register a new prover instance with TEE attestation quote
+     * @param _report The attestation report containing the TEE quote to be verified
+     * @param _data The report data containing prover details:
+     *        - addr: The prover's address
+     *        - teeType: Type of TEE (1 for IntelTDX)
+     *        - referenceBlockNumber: Block number for verification
+     *        - referenceBlockHash: Block hash for verification
+     *        - binHash: Hash of the binary
+     *        - ext: Additional extension data
+     * @dev Verifies the attestation report, checks for uniqueness and registers the prover.
+     * Emits an InstanceAdded event on successful registration.
+     * Reverts if block number validation fails, report was already used, or attestation verification fails.
+     */
     function register(bytes calldata _report, ReportData calldata _data) external {
         _checkBlockNumber(_data.referenceBlockNumber, _data.referenceBlockHash);
         bytes32 dataHash = keccak256(abi.encode(_data));
@@ -65,8 +96,7 @@ contract ProverRegistryVerifier is IVerifier, IProverRegistry, EssentialContract
         if (attestedReports[reportHash]) revert REPORT_USED();
         attestedReports[reportHash] = true;
 
-        uint256 instanceID = nextInstanceId + 1;
-        nextInstanceId += 1;
+        uint256 instanceID = ++nextInstanceId;
 
         uint256 validUnitl = block.timestamp + attestValiditySeconds;
         attestedProvers[instanceID] = ProverInstance(_data.addr, validUnitl, _data.teeType);
@@ -74,6 +104,12 @@ contract ProverRegistryVerifier is IVerifier, IProverRegistry, EssentialContract
         emit InstanceAdded(instanceID, _data.addr, address(0), validUnitl);
     }
 
+    /// @notice Verifies a proof submitted by a prover
+    /// @param _ctx The verification context including prover address and metadata
+    /// @param _tran The transition data for the proof
+    /// @param _proof The tier proof data containing instance ID and signatures
+    /// @dev Verifies the prover's signature and updates instance address if needed
+    /// @dev Does not run verification if contesting an existing proof
     function verifyProof(
         IVerifier.Context calldata _ctx,
         TaikoData.Transition calldata _tran,
@@ -107,15 +143,25 @@ contract ProverRegistryVerifier is IVerifier, IProverRegistry, EssentialContract
         }
     }
 
+    /// @notice Verifies a batch of proofs
+    /// @dev Currently not implemented
     function verifyBatchProof(
-        ContextV2[] calldata _ctxs,
-        TaikoData.TierProof calldata _proof
+        IVerifier.ContextV2[] calldata /* _ctxs */,
+        TaikoData.TierProof calldata /* _proof */
     )
         external
         pure
         notImplemented
     { }
 
+    /// @notice Validates a prover instance
+    /// @param _instanceID The ID of the prover instance to check
+    /// @param _proverAddr The expected address of the prover
+    /// @return ProverInstance The validated prover instance data
+    /// @dev Checks if:
+    ///      1. Instance ID is valid (not 0)
+    ///      2. Prover address matches registered address
+    ///      3. Instance hasn't expired
     function checkProver(
         uint256 _instanceID,
         address _proverAddr
@@ -131,8 +177,12 @@ contract ProverRegistryVerifier is IVerifier, IProverRegistry, EssentialContract
         if (prover.addr != _proverAddr) revert PROVER_ADDR_MISMATCH(prover.addr, _proverAddr);
         if (prover.validUntil < block.timestamp) revert PROVER_OUT_OF_DATE(prover.validUntil);
         return prover;
+        if (prover.validUntil < block.timestamp) revert PROVER_OUT_OF_DATE(prover.validUntil);
+        return prover;
     }
 
+    /// @notice Gets the UniFi chain ID from the TaikoL1 contract
+    /// @return The chain ID as configured in TaikoL1
     function uniFiChainId() public view virtual returns (uint64) {
         return ITaikoL1(resolve(LibStrings.B_TAIKO, false)).getConfig().chainId;
     }
@@ -144,8 +194,10 @@ contract ProverRegistryVerifier is IVerifier, IProverRegistry, EssentialContract
     // blocks
     function _checkBlockNumber(uint256 blockNumber, bytes32 blockHash) private view {
         if (blockNumber >= block.number) revert INVALID_BLOCK_NUMBER();
-        if (block.number - blockNumber >= maxBlockNumberDiff) {
-            revert BLOCK_NUMBER_OUT_OF_DATE();
+        unchecked {
+            if (block.number - blockNumber >= maxBlockNumberDiff) {
+                revert BLOCK_NUMBER_OUT_OF_DATE();
+            }
         }
         if (blockhash(blockNumber) != blockHash) revert BLOCK_NUMBER_MISMATCH();
     }

--- a/packages/protocol/contracts/layer1/verifiers/ProverRegistryVerifier.sol
+++ b/packages/protocol/contracts/layer1/verifiers/ProverRegistryVerifier.sol
@@ -24,6 +24,17 @@ contract ProverRegistryVerifier is IVerifier, IProverRegistry, EssentialContract
 
     uint256[46] private __gap;
 
+    /// @notice Initializes the ProverRegistryVerifier contract
+    /// @param _owner The address that will be granted ownership permissions
+    /// @param _rollupAddressManager The address of the rollup address manager
+    /// @param _verifierAddr The address of the attestation verifier contract. Cannot be address(0)
+    /// @param _attestValiditySeconds Duration in seconds for which an attestation remains valid
+    /// @param _maxBlockNumberDiff Maximum allowed difference between current and reference block numbers
+    /// @dev Sets up the contract with initial configuration and emits an event upon completion.
+    ///      Reverts if:
+    ///      1. _verifierAddr is address(0)
+    ///      2. _attestValiditySeconds is 0
+    ///      3. _maxBlockNumberDiff exceeds 256
     function init(
         address _owner,
         address _rollupAddressManager,

--- a/packages/protocol/contracts/layer1/verifiers/ProverRegistryVerifier.sol
+++ b/packages/protocol/contracts/layer1/verifiers/ProverRegistryVerifier.sol
@@ -50,7 +50,7 @@ contract ProverRegistryVerifier is IVerifier, IProverRegistry, EssentialContract
     {
         __Essential_init(_owner, _rollupAddressManager);
 
-        if (_verifierAddr == address(0)) revert PROVER_INVALID_ADDR(_verifierAddr);
+        if (_verifierAddr == address(0)) revert VERIFIER_INVALID_ADDR();
         if (_attestValiditySeconds == 0) revert INVALID_ATTEST_VALIDITY_SECONDS();
         if (_maxBlockNumberDiff > 256) revert MAX_BLOCK_NUMBER_DIFF_TOO_LARGE();
 
@@ -76,7 +76,7 @@ contract ProverRegistryVerifier is IVerifier, IProverRegistry, EssentialContract
         onlyOwner
         reinitializer(i)
     {
-        if (_verifierAddr == address(0)) revert PROVER_INVALID_ADDR(_verifierAddr);
+        if (_verifierAddr == address(0)) revert VERIFIER_INVALID_ADDR();
         if (_attestValiditySeconds == 0) revert INVALID_ATTEST_VALIDITY_SECONDS();
         if (_maxBlockNumberDiff > 256) revert MAX_BLOCK_NUMBER_DIFF_TOO_LARGE();
 
@@ -189,8 +189,6 @@ contract ProverRegistryVerifier is IVerifier, IProverRegistry, EssentialContract
         if (_proverAddr == address(0)) revert PROVER_INVALID_ADDR(_proverAddr);
         prover = attestedProvers[_instanceID];
         if (prover.addr != _proverAddr) revert PROVER_ADDR_MISMATCH(prover.addr, _proverAddr);
-        if (prover.validUntil < block.timestamp) revert PROVER_OUT_OF_DATE(prover.validUntil);
-        return prover;
         if (prover.validUntil < block.timestamp) revert PROVER_OUT_OF_DATE(prover.validUntil);
         return prover;
     }

--- a/packages/protocol/test/layer1/verifiers/ProverRegistryVerifier.t.sol
+++ b/packages/protocol/test/layer1/verifiers/ProverRegistryVerifier.t.sol
@@ -91,7 +91,7 @@ contract ProverRegistryVerifierTest is TaikoL1TestBase {
         });
     }
 
-    function _proofTransition() internal view returns (TaikoData.Transition memory transition) {
+    function _proofTransition() internal pure returns (TaikoData.Transition memory transition) {
         transition = TaikoData.Transition({
             parentHash: bytes32("12"),
             blockHash: bytes32("34"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Resolve the issues related to `ProverRegistry` and `AttestationVerifier` on OZ Audit report

#### Which issue(s) does this PR fixes:

<!--  For internal Puffer folks, please tag this PR to an internal user story ID for traceability -->



#### Additional comments:

| IssueID | Issue Name | Status |
|---|---|---|
| L-03 | Floating Pragma | Not Resolved. <br> This is because the contract currently aligns with the behavior of other contracts. |
| L-05 | Incomplete Docstrings | Resolved |
| L-06 | Missing Docstrings | Resolved |
| L-09 | Lack of Input Validation in the init Function of ProverRegistryVerifier | Resolved |
| L-10 | Possible Bypass of Attestation Verification in verifyAttestation | Not Resolved. <br> For mock mode testing, the system is designed to bypass <br> attestation verification when the `dcapAttestation` address is zero. <br> We’ve documented this behavior for clarity. |
| N-02 | Functions Updating State Without Event Emission | Resolved |
| N-04 | Code Optimization | Resolved |
| N-05 | State Variable Visibility Not Explicitly Declared | Resolved |

